### PR TITLE
No need to use keyword arguments for FolderPrompts

### DIFF
--- a/tests/test_basic_load.py
+++ b/tests/test_basic_load.py
@@ -28,7 +28,7 @@ def test_folder_prompts(test_folder_location):
     with tempfile.NamedTemporaryFile() as temp_file:
         base_prompts.save_prompt_report(temp_file.name)
 
-        new_base_prompts = FolderPrompts(prompt_folder=test_folder)
+        new_base_prompts = FolderPrompts(test_folder)
         new_base_prompts.load_from_prompt_report(temp_file.name)
         loaded_keys = new_base_prompts._prompts.keys()
         assert 'hello' in loaded_keys and 'test' in loaded_keys
@@ -80,7 +80,3 @@ def test_loading_errors():
         base_prompts = FolderPrompts(prompt_folder=prompt_folder)
 
     print("AssertionError correctly raised for non-existent file/directory.")
-
-    base_prompts = FolderPrompts()
-    base_prompts = JsonPrompts()
-    print("Created empty prompt classes!")

--- a/tests/test_json_validator.py
+++ b/tests/test_json_validator.py
@@ -1,12 +1,12 @@
 import os
 import pytest
 
-from wtprompt.utils.json_validator import validate_json, ValidationError
+from wtprompt.utils.json_validator import is_json_valid, ValidationError
 
 
 def test_correct_json(test_folder_location):
-    assert validate_json(os.path.join(test_folder_location, 'test_prompts', 'test.json'))
+    assert is_json_valid(os.path.join(test_folder_location, 'test_prompts', 'test.json'))
 
     with pytest.raises(ValidationError):
-        validate_json(os.path.join(test_folder_location, 'preprocessor_config.json'))
+        is_json_valid(os.path.join(test_folder_location, 'preprocessor_config.json'))
 

--- a/wtprompt/core.py
+++ b/wtprompt/core.py
@@ -10,7 +10,7 @@ from typing import Optional, Union, Tuple, Dict, List
 
 from pydantic import BaseModel, Field, field_validator
 
-from wtprompt.utils.json_validator import validate_json
+from wtprompt.utils.json_validator import is_json_valid
 
 from wtprompt.fill import PromptGenerator, fill_list
 
@@ -135,9 +135,9 @@ class FolderPrompts(PromptLoader):
     """
     prompt_folder: str = Field('', description="The folder containing .txt and .md files.")
 
-    def __init__(self, **data):
+    def __init__(self, prompt_folder:str):
         # Loading using pydantic validators
-        super().__init__(**data)
+        super().__init__(prompt_folder=prompt_folder)
         self._pre_prompt = ''
 
     def __str__(self):
@@ -265,10 +265,10 @@ class JsonPrompts(PromptLoader):
     prompt_file: str = Field('', description="The .json file containing the prompts.")
     validate_json: bool = Field(False, description="If True evaluates the JSON before loading it.")
 
-    def __init__(self, **data):
-        super().__init__(**data)
+    def __init__(self, prompt_file, validate_json=False):
+        super().__init__(prompt_file=prompt_file, validate_json=validate_json)
         if self.validate_json:
-            validate_json(self.prompt_file)
+            is_json_valid(self.prompt_file)
         # No support for lazy loading for json
         self.load()
 

--- a/wtprompt/utils/json_validator.py
+++ b/wtprompt/utils/json_validator.py
@@ -7,7 +7,7 @@ class ValidationError(Exception):
     pass
 
 
-def validate_json(filepath: str) -> bool:
+def is_json_valid(filepath: str) -> bool:
     """
     Validates a JSON file to ensure it exists, is a valid JSON,
     and that its content is a dictionary where values are either


### PR DESCRIPTION
Honestly there is no good reason for requiring the user to write prompt_folder...and no real advantage into empty folders.